### PR TITLE
fix: mouseEvent eventUsed contract (v1.2.3.0)

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -690,7 +690,9 @@ addModEventListener({
             print("[NPC Favor] npcSystem is nil in onSavegameLoaded")
         end
     end,
-    mouseEvent = function(self, posX, posY, isDown, isUp, button)
+    mouseEvent = function(self, posX, posY, isDown, isUp, button, eventUsed)
+        if eventUsed then return eventUsed end
+
         -- Guard helper: any GUI overlay or dialog is open
         local isGuiOpen = g_gui and (g_gui:getIsGuiVisible() or g_gui:getIsDialogVisible())
 
@@ -700,19 +702,19 @@ addModEventListener({
             if npcSystem and npcSystem.favorHUD then
                 -- Guard: not in vehicle
                 if g_localPlayer and g_localPlayer.getIsInVehicle and g_localPlayer:getIsInVehicle() then
-                    return
+                    return eventUsed
                 end
                 -- Guard: no GUI/dialog/popup open
                 if isGuiOpen then
-                    return
+                    return eventUsed
                 end
                 -- Guard: HUD not locked
                 if npcSystem.settings and npcSystem.settings.favorHudLocked then
-                    return
+                    return eventUsed
                 end
                 print("[NPC Favor] Right-click toggle via mouseEvent — editMode=" .. tostring(npcSystem.favorHUD.editMode))
                 npcSystem.favorHUD:toggleEditMode()
-                return
+                return true
             end
         end
 
@@ -722,8 +724,9 @@ addModEventListener({
             if isDown or isUp then
                 print(string.format("[NPC Favor] mouseEvent: btn=%d down=%s up=%s pos=%.3f,%.3f", button, tostring(isDown), tostring(isUp), posX, posY))
             end
-            npcSystem.favorHUD:mouseEvent(posX, posY, isDown, isUp, button)
+            eventUsed = npcSystem.favorHUD:mouseEvent(posX, posY, isDown, isUp, button, eventUsed) or eventUsed
         end
+        return eventUsed
     end
 })
 

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <modDesc descVersion="105">
     <author>TisonK</author>
-    <version>1.2.2.6-beta</version>
+    <version>1.2.3.0</version>
     <modName>FS25_NPCFavor</modName>
     <title>
         <en>NPC Favor - Living Neighborhood</en>

--- a/src/scripts/NPCFavorHUD.lua
+++ b/src/scripts/NPCFavorHUD.lua
@@ -200,8 +200,8 @@ end
 -- Mouse Event (drag logic)
 -- =========================================================
 
-function NPCFavorHUD:mouseEvent(posX, posY, isDown, isUp, button)
-    if not self.editMode then return end
+function NPCFavorHUD:mouseEvent(posX, posY, isDown, isUp, button, eventUsed)
+    if not self.editMode then return false end
 
     -- Check button clicks (edit mode only, left-click)
     if isDown and button == 1 then
@@ -210,7 +210,7 @@ function NPCFavorHUD:mouseEvent(posX, posY, isDown, isUp, button)
             print("[NPC Favor] HUD button clicked: " .. btn.id)
             self:exitEditMode()
             DialogLoader.show(btn.action, "setNPCSystem", self.npcSystem)
-            return
+            return true
         end
     end
 
@@ -225,7 +225,7 @@ function NPCFavorHUD:mouseEvent(posX, posY, isDown, isUp, button)
             self.resizing = false
             self.edgeDragStartX = posX
             self.edgeDragStartWidth = self.widthMult
-            return
+            return true
         end
 
         -- Check corner handles (uniform scale resize)
@@ -238,7 +238,7 @@ function NPCFavorHUD:mouseEvent(posX, posY, isDown, isUp, button)
             self.resizeStartMouseX = posX
             self.resizeStartMouseY = posY
             self.resizeStartScale = self.scale
-            return
+            return true
         end
 
         -- Fall through to drag if click is on body
@@ -299,6 +299,8 @@ function NPCFavorHUD:mouseEvent(posX, posY, isDown, isUp, button)
         self.widthMult = math.max(self.MIN_WIDTH_MULT, math.min(self.MAX_WIDTH_MULT, newMult))
         self:clampPosition()
     end
+
+    return true
 end
 
 -- =========================================================


### PR DESCRIPTION
## Summary
- Add `eventUsed` parameter to `addModEventListener` mouseEvent handler in `main.lua`
- Guard against already-consumed events; return `true` when consuming, propagate otherwise
- Add `eventUsed` param + correct return values to `NPCFavorHUD:mouseEvent`

## Test plan
- [ ] Right-click HUD toggle still works on foot
- [ ] RMB in vehicle no longer triggers HUD edit mode
- [ ] HUD drag/resize in edit mode still works
- [ ] Other mods' mouse listeners receive correct `eventUsed` state after NPC Favor consumes