### PR TITLE
feat(esc): NPC Favor framework table - freeze grid and shared empty-hint restore

### DIFF
--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <modDesc descVersion="105">
     <author>TisonK</author>
-    <version>1.2.7.65</version>
+    <version>1.2.7.66</version>
     <modName>FS25_NPCFavor</modName>
     <title>
         <en>NPC Favor - Living Neighborhood</en>

--- a/src/gui/NpcRfPdaGuest.lua
+++ b/src/gui/NpcRfPdaGuest.lua
@@ -436,11 +436,123 @@ local function resetFwTableTitlePos(container)
         end
         return
     end
-    el:setPosition(GuiUtils.getNormalizedXValue("0px", 0), GuiUtils.getNormalizedYValue("0px", 0))
+    -- BUILD 21:41: 0 / 0 is the PRE-16:32 baseline. The shared XML has had this title
+    -- at 10 / -8 since the white-card inset, so the old reset handed it back to a place
+    -- that no longer exists. Same miss Depot had.
+    el:setPosition(GuiUtils.getNormalizedXValue("10px", 0), GuiUtils.getNormalizedYValue("-8px", 0))
     if type(el.updateAbsolutePosition) == "function" then el:updateAbsolutePosition() end
 end
 
+-- ============================================================
+-- BUILD 21:41: the column grid, applied every show.
+-- ============================================================
+-- All four Table guests (Income, Depot, Dairy, NPC Favor) paint into the SAME shared
+-- elements, so whichever ran last leaves its geometry behind for the next one. Every guest
+-- therefore has to state its own grid on entry rather than assume the XML baseline, or it
+-- inherits the previous module's columns. This block is the XML freeze.
+--
+-- Y IS HELD. Each move reads the element's own current Y and writes it straight back, and
+-- setSize keeps the element's own height, so this can only ever change X and width.
+--
+-- Positions and sizes are NORMALISED in FS25, so everything goes through GuiUtils. A raw
+-- pixel integer here would throw the row off the screen.
+local FW_GRID_COLS = {
+    { "A", "10px", "280px" },
+    { "B", "310px", "280px" },
+    { "C", "610px", "220px" },
+    { "D", "850px", "280px" },
+}
+local FW_GRID_RULES = { "300px", "600px", "840px" }
+local _fwGridWarned = false
+
+local function applyFwGrid(container)
+    if GuiUtils == nil or type(GuiUtils.getNormalizedXValue) ~= "function"
+        or type(GuiUtils.getNormalizedScreenValues) ~= "function" then
+        if not _fwGridWarned then
+            _fwGridWarned = true
+            print("[RF] applyFwGrid: GuiUtils normalizer absent - leaving the XML grid")
+        end
+        return
+    end
+
+    local function place(el, xPx, wPx)
+        if el == nil then return end
+        if type(el.setPosition) == "function" and el.position ~= nil then
+            el:setPosition(GuiUtils.getNormalizedXValue(xPx, 0), el.position[2])
+        end
+        if wPx ~= nil and type(el.setSize) == "function" and el.size ~= nil then
+            local norms = GuiUtils.getNormalizedScreenValues(wPx .. " 1px")
+            if type(norms) == "table" and norms[1] ~= nil then
+                el:setSize(norms[1], el.size[2])
+            end
+        end
+        if type(el.updateAbsolutePosition) == "function" then el:updateAbsolutePosition() end
+    end
+
+    -- BUILD 21:54: this was ipairs over a table my generator had written with ",," between
+    -- entries, which puts a nil at the skipped index. ipairs stops at the first nil, so only
+    -- column A was ever placed and B, C and D stayed on the freeze XML while the rules moved
+    -- anyway. A literal 1..4 walk cannot be truncated by a hole, and skipping a nil entry
+    -- costs one column rather than throwing inside onShow.
+    for i = 1, 4 do
+        local c = FW_GRID_COLS[i]
+        if c ~= nil then
+            local letter, xPx, wPx = c[1], c[2], c[3]
+            place(findDescendant(container, "rfFwCol" .. letter), xPx, wPx)
+            for row = 1, 8 do
+                place(findDescendant(container, "rfFwRow" .. row .. letter), xPx, wPx)
+            end
+        end
+    end
+    -- Vertical rules keep their own Y and their 1px width; only the column boundary moves.
+    for i, xPx in ipairs(FW_GRID_RULES) do
+        place(findDescendant(container, "rfFwRuleCol" .. i), xPx, nil)
+    end
+end
+
+-- ============================================================
+-- BUILD 07:06: put the shared empty-hint box back.
+-- ============================================================
+-- rfFwEmptyHint is ONE element behind all nine doors. Income and Depot now shrink it to bay A
+-- (10 / 280 / -68 / 22) so their empty notice sits in the first cell instead of running across
+-- the grid. applyFwGrid does not list that id, so without this an empty Income visited earlier
+-- in the same session leaves this page's notice in a 280x22 box.
+--
+-- This page never uses bay A. It restores the XML numbers verbatim, every show, before the
+-- text is set, so the notice is painted into a box that is already the right size.
+local FW_HINT_X = "10px"
+local FW_HINT_Y = "-68px"
+local FW_HINT_W = "1120px"
+local FW_HINT_H = "44px"
+
+local function restoreFwEmptyHintBox(container)
+    local el = findDescendant(container, "rfFwEmptyHint")
+    if el == nil then
+        return
+    end
+    if GuiUtils == nil or type(GuiUtils.getNormalizedXValue) ~= "function"
+        or type(GuiUtils.getNormalizedYValue) ~= "function"
+        or type(GuiUtils.getNormalizedScreenValues) ~= "function" then
+        return
+    end
+    el.textMaxNumLines = 2
+    local norms = GuiUtils.getNormalizedScreenValues(FW_HINT_W .. " " .. FW_HINT_H)
+    if type(norms) ~= "table" or norms[1] == nil or norms[2] == nil then
+        return
+    end
+    if type(el.setSize) == "function" then
+        el:setSize(norms[1], norms[2])
+    end
+    if type(el.setPosition) == "function" then
+        el:setPosition(GuiUtils.getNormalizedXValue(FW_HINT_X, 0),
+                       GuiUtils.getNormalizedYValue(FW_HINT_Y, 0))
+        if type(el.updateAbsolutePosition) == "function" then el:updateAbsolutePosition() end
+    end
+end
+
 function NpcRfPdaGuest.onShow(container, lightOnly)
+    applyFwGrid(container)
+    restoreFwEmptyHintBox(container)
     resetFwTableTitlePos(container)
     clearHostDupes(container)
     showTableMode(container)


### PR DESCRIPTION
Brings the Esc framework table work that development has not seen: the freeze grid applied
every onShow before any setText, optical centring of the header and row words by X only after
setText so the freeze size is kept, and the empty notice locked into cell A1 rather than
centred across the sheet.

The empty notice is the part with a real trap behind it. rfFwEmptyHint is one element shared
by all the Esc doors, so shrinking it to bay A is only safe because every other page restores
it; one function owns its X, Y, width, height and line count in both states, because splitting
those across two passes is what left an earlier build correctly placed vertically and wrong
horizontally. The box is never measured and never nudged: 280 wide at X 10 leaves ten pixels
to the rule at 300 and an optical nudge spends all of it.

onShow becomes a thin wrapper so the placement runs even on the refusal paths, which is
exactly the empty-table case that needs it.